### PR TITLE
Cleanup & add titles

### DIFF
--- a/big.js
+++ b/big.js
@@ -19,7 +19,7 @@ window.onload = function() {
             e.style.fontSize = (i -= 10) + 'px';
         }
         if (window.location.hash !== n) window.location.hash = n;
-        document.title = s[n].textContent || s[n].innerText;
+        document.title = e.textContent || e.innerText;
     }
     document.onclick = function() {
         go(++cur % (s.length));


### PR DESCRIPTION
Hi! I liked your keynote at WhereCamp Boston, and was checking out the slides afterwards. After I went through the slides, I found my browser history a bit difficult to navigate, since no titles were used on the slides. I figured that since the slide contents themselves are short enough to fit into a page title, I could just use that, so I stuffed the contents into the title. A possible enhancement would be to also append the contents of the `<title>` element, so that you could see the title of the entire presentation as well, but since none of your presentations have titles, I didn't bother.

While I was modifying the code, I decided to do some cleanup, removing some repeated patterns in the code.

Each of those changes is a separate branch: `titles` and `cleanup`. I'm sending you the pull request for the merge, in `master`, but if you decide you like one or the other, you can grab them individually.
