### PR TITLE
background color unification

### DIFF
--- a/big.js
+++ b/big.js
@@ -12,6 +12,7 @@ window.onload = function() {
             e.firstChild.style.display = 'none';
         } else {
             document.body.style.backgroundImage = '';
+            document.body.style.backgroundColor = e.style.backgroundColor;
         }
         while (
             e.offsetWidth > window.innerWidth ||


### PR DESCRIPTION
Set the background color of the body to the background color of the div. This is rare but it happens when you have an image that is not the background and a little text the width of the div ends up not being the size of the entire page so there is a black bar on the right without this code.
