### PR TITLE
Fix firstChild.nodeName error for empty slides (CSS background)

### DIFF
--- a/big.js
+++ b/big.js
@@ -9,7 +9,7 @@ window.onload = function() {
         for (var k = 0; k < s.length; k++) s[k].style.display = 'none';
         e.style.display = 'inline';
         e.style.fontSize = i + 'px';
-        if (e.firstChild.nodeName === 'IMG') {
+        if (e.firstChild && e.firstChild.nodeName === 'IMG') {
             document.body.style.backgroundImage = 'url(' + e.firstChild.src + ')';
             e.firstChild.style.display = 'none';
             if ('classList' in e) e.classList.add('imageText');


### PR DESCRIPTION
One of the members of our team wanted a background on a slide, but didn't want it to be fullscreen. So he created an empty div and used CSS to apply a tiling background to it:

```
<div class="center" data-bodyclass="unification"></div>
<style>
    .unification { background: url('http://31.media.tumblr.com/tumblr_m6dxt5mWaD1qljgz7o1_1280.gif'); }
</style>
```

This caused an error when Big attempted to check the `firstChild` property of the div (because it was empty).

`Uncaught TypeError: Cannot read property 'nodeName' of null`

So this checks to make sure there IS a firstChild before proceeding.
