### PR TITLE
Prepare big.js to be registered with Bower.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,15 @@
+{
+  "name": "big.js",
+  "main": "big.js",
+  "version": "1.0.0",
+  "homepage": "https://github.com/tmcw/big",
+  "authors": [
+    "Tom MacWright <tom@macwright.org>"
+  ],
+  "description": "presentations for busy messy hackers",
+  "keywords": [
+    "slides",
+    "presentations"
+  ],
+  "license": "The person who associated a work with this deed has dedicated the work to the public domain by waiving all of his or her rights to the work worldwide under copyright law, including all related and neighboring rights, to the extent allowed by law."
+}


### PR DESCRIPTION
I thought it would be really useful to have big.js be [available via Bower](http://bower.io/docs/creating-packages/). Would make it really handy to be able to install it with a single command (`bower install bigjs`) or something like that. I've prepped a bower.json in this PR with the values I think are appropriate.

The next step is to create a tag based on current version. I used 1.0.0 since big has been around 2011, but it can be whatever you prefer. Then big needs to be registered. It looks like that can be done by anyone because it will just point to your repo. The only thing I wasn't sure about was the name. `big.js` is already taken, but interestingly `big` is not. This is from a search of the bower repo just now.

```
    bignumber.js git://github.com/MikeMcl/bignumber.js.git
    big.js git://github.com/MikeMcl/big.js.git
    BigVideo.js git://github.com/dfcb/BigVideo.js.git
    bigbird git://github.com/madebymany/bigbird.git
    bigscreen git://github.com/bdougherty/BigScreen.git
    bigtext git://github.com/zachleat/BigText.git
    bigSlide git://github.com/ascott1/bigSlide.js.git
    bigvideo.js git://github.com/dfcb/BigVideo.js.git
    bigfoot git://github.com/pxldot/bigfoot
    bootstrap-big-grid git://github.com/BenWhitehead/bootstrap-big-grid.git
    angular-jsbn-big-integer git://github.com/andyperlitch/angular-jsbn-big-integer.git
    BigParallax git://github.com/fnobi/BigParallax
    cryptocoin-bigint git://github.com/cryptocoinjs/bigint.git
    big-surface git://github.com/ozanturgut/big-surface.git
    bigi git://github.com/cryptocoinjs/bigi.git
    angular-big git://github.com/chemisus/angular-big.git
    bigot git://github.com/FireZenk/bigot.git
    javascript-biginteger git://github.com/lu4/javascript-biginteger.git
```

Thoughts?
