### PR TITLE
focus shifts to current page (screen reader accessible)

### DIFF
--- a/big.css
+++ b/big.css
@@ -49,3 +49,8 @@ div.imageText {
 notes {
     display:none;
 }
+/* normally not good, but ok in context of full screen direcitonal navigation */
+:focus {
+    outline: 0;
+}
+

--- a/big.css
+++ b/big.css
@@ -49,7 +49,7 @@ div.imageText {
 notes {
     display:none;
 }
-/* normally not good, but ok in context of full screen direcitonal navigation */
+/* normally not good, but ok in context of full screen directional navigation */
 :focus {
     outline: 0;
 }

--- a/big.js
+++ b/big.js
@@ -1,5 +1,6 @@
 window.onload = function() {
     var s = document.getElementsByTagName('div'), ti;
+    for (var k = 0; k < s.length; k++) {s[k].setAttribute('tabindex', 0);}
     if (!s) return;
     var big = { current: 0, forward: fwd, reverse: rev, go: go, length: s.length };
     window.big = big;
@@ -18,6 +19,7 @@ window.onload = function() {
         document.body.className = e.getAttribute('data-bodyclass') || '';
         for (var k = 0; k < s.length; k++) s[k].style.display = 'none';
         e.style.display = 'inline';
+        e.focus();
         for (k = 0; typeof console === 'object' && k < notes.length; k++) console.log('%c%s: %s', 'padding:5px;font-family:serif;font-size:18px;line-height:150%;', n, notes[k].innerHTML.trim());
         if (e.firstChild && e.firstChild.nodeName === 'IMG') {
             document.body.style.backgroundImage = 'url("' + e.firstChild.src + '")';

--- a/big.js
+++ b/big.js
@@ -1,6 +1,6 @@
 window.onload = function() {
     var s = document.getElementsByTagName('div'), ti;
-    for (var k = 0; k < s.length; k++) {s[k].setAttribute('tabindex', 0);}
+    for (var k = 0; k < s.length; k++) s[k].setAttribute('tabindex', 0);
     if (!s) return;
     var big = { current: 0, forward: fwd, reverse: rev, go: go, length: s.length };
     window.big = big;

--- a/big.quickstart.html
+++ b/big.quickstart.html
@@ -50,9 +50,15 @@ div.imageText {
 notes {
     display:none;
 }
+/* normally not good, but ok in context of full screen direcitonal navigation */
+:focus {
+    outline: 0;
+}
+
 </style><script type='text/javascript'>
 window.onload = function() {
     var s = document.getElementsByTagName('div'), ti;
+    for (var k = 0; k < s.length; k++) {s[k].setAttribute('tabindex', 0);}
     if (!s) return;
     var big = { current: 0, forward: fwd, reverse: rev, go: go, length: s.length };
     window.big = big;
@@ -71,6 +77,7 @@ window.onload = function() {
         document.body.className = e.getAttribute('data-bodyclass') || '';
         for (var k = 0; k < s.length; k++) s[k].style.display = 'none';
         e.style.display = 'inline';
+        e.focus();
         for (k = 0; typeof console === 'object' && k < notes.length; k++) console.log('%c%s: %s', 'padding:5px;font-family:serif;font-size:18px;line-height:150%;', n, notes[k].innerHTML.trim());
         if (e.firstChild && e.firstChild.nodeName === 'IMG') {
             document.body.style.backgroundImage = 'url("' + e.firstChild.src + '")';


### PR DESCRIPTION
By adding an attribute of "tabindex=0" to the ```<div>```'s, we can ensure that each page's content will be read aloud by setting the focus on it in the go() method.  

Default browser styling for :focus has been overridden.

More info: http://webaim.org/techniques/keyboard/tabindex

Thanks!