### PR TITLE
Page relative units

### DIFF
--- a/big.css
+++ b/big.css
@@ -1,6 +1,5 @@
 body {
   font-family:'Helvetica';
-  letter-spacing:-5px;
   background:#000;
   background-size:100%;
   color:#fff;
@@ -34,7 +33,7 @@ body > div {
   position:absolute;
   top:0px;
   left:0px;
-  padding:75px;
+  padding:10%;
   line-height:97%;
 }
 

--- a/big.css
+++ b/big.css
@@ -33,8 +33,8 @@ body > div {
   position:absolute;
   top:0px;
   left:0px;
-  padding:10%;
-  line-height:97%;
+  padding:4%;
+  line-height:100%;
 }
 
 div.center {

--- a/demo.html
+++ b/demo.html
@@ -13,6 +13,11 @@
 </div>
 <div class='center'><em>Presentation software</em> for busy busy hackers</div>
 <div>+text</div>
+<div><pre>// and
+var code = true;
+function javascript() {
+  return probably;
+}</div>
 <div>as <em>big</em> as it can be</div>
 <div>with <div style='font-style:italic;background:#555;'>normal HTML</div></div>
 <div data-time-to-next='3'>and now it's perfect for ignite talks (wait 3 seconds)</div>


### PR DESCRIPTION
@Miserlou - this removes the size-independent `letter-spacing` property that was making your pre tags look really bad, but it may not resolve the entire problem. Can you test with this updated stylesheet and post an example if the issue persists?