### PR TITLE
Remove broken links

### DIFF
--- a/index.html
+++ b/index.html
@@ -126,8 +126,6 @@ python -m SimpleHTTPServer</pre>
 <div class='content'>
     <h2>Examples</h2>
     <ul class='clearfix'>
-        <li><a href="http://exposedata.com/talk/d3-geo/#0">d3-geo</a>
-        <li><a href="http://bdon.org/talk-2013-1-29.html#0">THREE.js + geo</a>
         <li><a href="http://macwright.org/presentations/beyond/">FOSS4G: Beyond</a></li>
         <li><a href="http://macwright.org/presentations/projections/#0">Project It Yourself</a></li>
         <li><a href="http://macwright.org/presentations/carto/">Carto</a></li>


### PR DESCRIPTION
It seems like exposedata.com isn't a registered domain anymore and bdon.org can't find the page.