### PR TITLE
Use event.key instead of event.which

### DIFF
--- a/lib/big.js
+++ b/lib/big.js
@@ -395,13 +395,27 @@ window.addEventListener('load', function() {
   }
 
   function onKeyDown(e) {
-    if (big.mode == 'talk') {
-      if (e.which === 39 || e.which === 34 || e.which === 40) forward();
-      if (e.which === 37 || e.which === 33 || e.which === 38) reverse();
+    switch (e.key) {
+    case "ArrowLeft":
+    case "ArrowUp":
+    case "PageUp":
+      if (big.mode === "talk") reverse();
+      break;
+    case "ArrowRight":
+    case "ArrowDown":
+    case "PageDown":
+      if (big.mode === "talk") forward();
+      break;
+    case "p":
+      onPrint();
+      break;
+    case "t":
+      onTalk();
+      break;
+    case "j":
+      onJump();
+      break;
     }
-    if (e.which === 80) onPrint();
-    if (e.which === 84) onTalk();
-    if (e.which === 74) onJump();
   }
 
   function onTouchStart(e) {


### PR DESCRIPTION
Event.which is used by big, but is deprecated from web standards. KeyboardEvent.key is the 'correct' way to do it. This does _cut IE8 support_ but I suspect we don't have IE8 support anyway, given that we use a bunch of other more modern JavaScript features.

Fixes #129