### PR TITLE
Fix main export

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "big-presentation",
   "version": "3.4.0",
   "description": "a presentation system for busy messy hackers",
-  "main": "big.js",
+  "main": "lib/big.js",
   "scripts": {
     "test": "stylelint lib/big.css && flow",
     "doc": "documentation build lib/big.js -o docs/api.md -f md --access=public",


### PR DESCRIPTION
I set up my preferred big presentation boilerplate this evening, and noticed the main export of this package is messed up: https://github.com/bcomnes/big-presentation-boilerplate/blob/master/src/index.js#L1 

This fixes the main export.